### PR TITLE
Fix #3 Remove @@personal-information from the ignore list.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,21 +4,26 @@ Changelog
 0.1-dev (unreleased)
 --------------------
 
+- #3 Remove @@personal-information from the 2-Factor ignore list.
+  This way the user isn't able to surf to /@@personal-information while
+  he didn't put its SMS/EMail code in.
+  [pcdummy]
+
 - Package created using templer
   [frapell]
 
 - Include dependency with the Twilio service wrapper
   [frapell]
-  
+
 - Include two-factor authentication over Email and SMS.
   [frapell]
-  
+
 - Subscribe to the IPubSuccess event for checking if the current member
   needs to be asked for an authentication token
   [frapell]
-  
+
 - Create a control panel for managing Twilio settings.
   [frapell]
-  
+
 - Use schemaextender to support Products.remember
   [frapell]

--- a/src/collective/twofactor/profiles/default/registry.xml
+++ b/src/collective/twofactor/profiles/default/registry.xml
@@ -40,7 +40,6 @@
     </field>
     <value>
       <element>two-factor-challenge</element>
-      <element>@@personal-information</element>
       <element>logout</element>
       <element>.css</element>
       <element>.js</element>


### PR DESCRIPTION
This way the user isn't able to surf to /@@personal-information while
he didn't put its SMS/EMail code in.

This fixes issue #3 but only for fresh installations, want an Upgrade step?

Signed-off-by: Rene Jochum rene@jochums.at
